### PR TITLE
Scaffold premonition

### DIFF
--- a/app/assets/javascripts/premonitions.js.coffee
+++ b/app/assets/javascripts/premonitions.js.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/premonitions.css.scss
+++ b/app/assets/stylesheets/premonitions.css.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Premonitions controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/premonitions_controller.rb
+++ b/app/controllers/premonitions_controller.rb
@@ -1,0 +1,74 @@
+class PremonitionsController < ApplicationController
+  before_action :set_premonition, only: [:show, :edit, :update, :destroy]
+
+  # GET /premonitions
+  # GET /premonitions.json
+  def index
+    @premonitions = Premonition.all
+  end
+
+  # GET /premonitions/1
+  # GET /premonitions/1.json
+  def show
+  end
+
+  # GET /premonitions/new
+  def new
+    @premonition = Premonition.new
+  end
+
+  # GET /premonitions/1/edit
+  def edit
+  end
+
+  # POST /premonitions
+  # POST /premonitions.json
+  def create
+    @premonition = Premonition.new(premonition_params)
+
+    respond_to do |format|
+      if @premonition.save
+        format.html { redirect_to @premonition, notice: 'Premonition was successfully created.' }
+        format.json { render action: 'show', status: :created, location: @premonition }
+      else
+        format.html { render action: 'new' }
+        format.json { render json: @premonition.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # PATCH/PUT /premonitions/1
+  # PATCH/PUT /premonitions/1.json
+  def update
+    respond_to do |format|
+      if @premonition.update(premonition_params)
+        format.html { redirect_to @premonition, notice: 'Premonition was successfully updated.' }
+        format.json { head :no_content }
+      else
+        format.html { render action: 'edit' }
+        format.json { render json: @premonition.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # DELETE /premonitions/1
+  # DELETE /premonitions/1.json
+  def destroy
+    @premonition.destroy
+    respond_to do |format|
+      format.html { redirect_to premonitions_url }
+      format.json { head :no_content }
+    end
+  end
+
+  private
+    # Use callbacks to share common setup or constraints between actions.
+    def set_premonition
+      @premonition = Premonition.find(params[:id])
+    end
+
+    # Never trust parameters from the scary internet, only allow the white list through.
+    def premonition_params
+      params.require(:premonition).permit(:title, :date, :type, :type_description, :description, :location_user, :location_premonition, :premonition_come_true, :premonition_come_true_description, :someone_else, :own_conclusions, :more_premonitions, :tags, :status)
+    end
+end

--- a/app/helpers/premonitions_helper.rb
+++ b/app/helpers/premonitions_helper.rb
@@ -1,0 +1,2 @@
+module PremonitionsHelper
+end

--- a/app/models/premonition.rb
+++ b/app/models/premonition.rb
@@ -1,0 +1,17 @@
+class Premonition
+  include Mongoid::Document
+  field :title, type: String
+  field :date, type: String
+  field :type, type: String
+  field :type_description, type: String
+  field :description, type: String
+  field :location_user, type: String
+  field :location_premonition, type: String
+  field :premonition_come_true, type: String
+  field :premonition_come_true_description, type: String
+  field :someone_else, type: String
+  field :own_conclusions, type: String
+  field :more_premonitions, type: String
+  field :tags, type: String
+  field :status, type: Integer
+end

--- a/app/views/premonitions/_form.html.erb
+++ b/app/views/premonitions/_form.html.erb
@@ -1,0 +1,73 @@
+<%= form_for(@premonition) do |f| %>
+  <% if @premonition.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(@premonition.errors.count, "error") %> prohibited this premonition from being saved:</h2>
+
+      <ul>
+      <% @premonition.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= f.label :title %><br>
+    <%= f.text_field :title %>
+  </div>
+  <div class="field">
+    <%= f.label :date %><br>
+    <%= f.text_field :date %>
+  </div>
+  <div class="field">
+    <%= f.label :type %><br>
+    <%= f.text_field :type %>
+  </div>
+  <div class="field">
+    <%= f.label :type_description %><br>
+    <%= f.text_field :type_description %>
+  </div>
+  <div class="field">
+    <%= f.label :description %><br>
+    <%= f.text_field :description %>
+  </div>
+  <div class="field">
+    <%= f.label :location_user %><br>
+    <%= f.text_field :location_user %>
+  </div>
+  <div class="field">
+    <%= f.label :location_premonition %><br>
+    <%= f.text_field :location_premonition %>
+  </div>
+  <div class="field">
+    <%= f.label :premonition_come_true %><br>
+    <%= f.text_field :premonition_come_true %>
+  </div>
+  <div class="field">
+    <%= f.label :premonition_come_true_description %><br>
+    <%= f.text_field :premonition_come_true_description %>
+  </div>
+  <div class="field">
+    <%= f.label :someone_else %><br>
+    <%= f.text_field :someone_else %>
+  </div>
+  <div class="field">
+    <%= f.label :own_conclusions %><br>
+    <%= f.text_field :own_conclusions %>
+  </div>
+  <div class="field">
+    <%= f.label :more_premonitions %><br>
+    <%= f.text_field :more_premonitions %>
+  </div>
+  <div class="field">
+    <%= f.label :tags %><br>
+    <%= f.text_field :tags %>
+  </div>
+  <div class="field">
+    <%= f.label :status %><br>
+    <%= f.number_field :status %>
+  </div>
+  <div class="actions">
+    <%= f.submit %>
+  </div>
+<% end %>

--- a/app/views/premonitions/edit.html.erb
+++ b/app/views/premonitions/edit.html.erb
@@ -1,0 +1,6 @@
+<h1>Editing premonition</h1>
+
+<%= render 'form' %>
+
+<%= link_to 'Show', @premonition %> |
+<%= link_to 'Back', premonitions_path %>

--- a/app/views/premonitions/index.html.erb
+++ b/app/views/premonitions/index.html.erb
@@ -1,0 +1,51 @@
+<h1>Listing premonitions</h1>
+
+<table>
+  <thead>
+    <tr>
+      <th>Title</th>
+      <th>Date</th>
+      <th>Type</th>
+      <th>Type description</th>
+      <th>Description</th>
+      <th>Location user</th>
+      <th>Location premonition</th>
+      <th>Premonition come true</th>
+      <th>Premonition come true description</th>
+      <th>Someone else</th>
+      <th>Own conclusions</th>
+      <th>More premonitions</th>
+      <th>Tags</th>
+      <th>Status</th>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @premonitions.each do |premonition| %>
+      <tr>
+        <td><%= premonition.title %></td>
+        <td><%= premonition.date %></td>
+        <td><%= premonition.type %></td>
+        <td><%= premonition.type_description %></td>
+        <td><%= premonition.description %></td>
+        <td><%= premonition.location_user %></td>
+        <td><%= premonition.location_premonition %></td>
+        <td><%= premonition.premonition_come_true %></td>
+        <td><%= premonition.premonition_come_true_description %></td>
+        <td><%= premonition.someone_else %></td>
+        <td><%= premonition.own_conclusions %></td>
+        <td><%= premonition.more_premonitions %></td>
+        <td><%= premonition.tags %></td>
+        <td><%= premonition.status %></td>
+        <td><%= link_to 'Show', premonition %></td>
+        <td><%= link_to 'Edit', edit_premonition_path(premonition) %></td>
+        <td><%= link_to 'Destroy', premonition, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<br>
+
+<%= link_to 'New Premonition', new_premonition_path %>

--- a/app/views/premonitions/index.json.jbuilder
+++ b/app/views/premonitions/index.json.jbuilder
@@ -1,0 +1,4 @@
+json.array!(@premonitions) do |premonition|
+  json.extract! premonition, :id, :title, :date, :type, :type_description, :description, :location_user, :location_premonition, :premonition_come_true, :premonition_come_true_description, :someone_else, :own_conclusions, :more_premonitions, :tags, :status
+  json.url premonition_url(premonition, format: :json)
+end

--- a/app/views/premonitions/new.html.erb
+++ b/app/views/premonitions/new.html.erb
@@ -1,0 +1,5 @@
+<h1>New premonition</h1>
+
+<%= render 'form' %>
+
+<%= link_to 'Back', premonitions_path %>

--- a/app/views/premonitions/show.html.erb
+++ b/app/views/premonitions/show.html.erb
@@ -1,0 +1,74 @@
+<p id="notice"><%= notice %></p>
+
+<p>
+  <strong>Title:</strong>
+  <%= @premonition.title %>
+</p>
+
+<p>
+  <strong>Date:</strong>
+  <%= @premonition.date %>
+</p>
+
+<p>
+  <strong>Type:</strong>
+  <%= @premonition.type %>
+</p>
+
+<p>
+  <strong>Type description:</strong>
+  <%= @premonition.type_description %>
+</p>
+
+<p>
+  <strong>Description:</strong>
+  <%= @premonition.description %>
+</p>
+
+<p>
+  <strong>Location user:</strong>
+  <%= @premonition.location_user %>
+</p>
+
+<p>
+  <strong>Location premonition:</strong>
+  <%= @premonition.location_premonition %>
+</p>
+
+<p>
+  <strong>Premonition come true:</strong>
+  <%= @premonition.premonition_come_true %>
+</p>
+
+<p>
+  <strong>Premonition come true description:</strong>
+  <%= @premonition.premonition_come_true_description %>
+</p>
+
+<p>
+  <strong>Someone else:</strong>
+  <%= @premonition.someone_else %>
+</p>
+
+<p>
+  <strong>Own conclusions:</strong>
+  <%= @premonition.own_conclusions %>
+</p>
+
+<p>
+  <strong>More premonitions:</strong>
+  <%= @premonition.more_premonitions %>
+</p>
+
+<p>
+  <strong>Tags:</strong>
+  <%= @premonition.tags %>
+</p>
+
+<p>
+  <strong>Status:</strong>
+  <%= @premonition.status %>
+</p>
+
+<%= link_to 'Edit', edit_premonition_path(@premonition) %> |
+<%= link_to 'Back', premonitions_path %>

--- a/app/views/premonitions/show.json.jbuilder
+++ b/app/views/premonitions/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.extract! @premonition, :id, :title, :date, :type, :type_description, :description, :location_user, :location_premonition, :premonition_come_true, :premonition_come_true_description, :someone_else, :own_conclusions, :more_premonitions, :tags, :status, :created_at, :updated_at

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
   
+  resources :premonitions
+
   root 'pages#home'
 
   resources :users

--- a/test/controllers/premonitions_controller_test.rb
+++ b/test/controllers/premonitions_controller_test.rb
@@ -1,0 +1,49 @@
+require 'test_helper'
+
+class PremonitionsControllerTest < ActionController::TestCase
+  setup do
+    @premonition = premonitions(:one)
+  end
+
+  test "should get index" do
+    get :index
+    assert_response :success
+    assert_not_nil assigns(:premonitions)
+  end
+
+  test "should get new" do
+    get :new
+    assert_response :success
+  end
+
+  test "should create premonition" do
+    assert_difference('Premonition.count') do
+      post :create, premonition: { date: @premonition.date, description: @premonition.description, location_premonition: @premonition.location_premonition, location_user: @premonition.location_user, more_premonitions: @premonition.more_premonitions, own_conclusions: @premonition.own_conclusions, premonition_come_true: @premonition.premonition_come_true, premonition_come_true_description: @premonition.premonition_come_true_description, someone_else: @premonition.someone_else, status: @premonition.status, tags: @premonition.tags, title: @premonition.title, type: @premonition.type, type_description: @premonition.type_description }
+    end
+
+    assert_redirected_to premonition_path(assigns(:premonition))
+  end
+
+  test "should show premonition" do
+    get :show, id: @premonition
+    assert_response :success
+  end
+
+  test "should get edit" do
+    get :edit, id: @premonition
+    assert_response :success
+  end
+
+  test "should update premonition" do
+    patch :update, id: @premonition, premonition: { date: @premonition.date, description: @premonition.description, location_premonition: @premonition.location_premonition, location_user: @premonition.location_user, more_premonitions: @premonition.more_premonitions, own_conclusions: @premonition.own_conclusions, premonition_come_true: @premonition.premonition_come_true, premonition_come_true_description: @premonition.premonition_come_true_description, someone_else: @premonition.someone_else, status: @premonition.status, tags: @premonition.tags, title: @premonition.title, type: @premonition.type, type_description: @premonition.type_description }
+    assert_redirected_to premonition_path(assigns(:premonition))
+  end
+
+  test "should destroy premonition" do
+    assert_difference('Premonition.count', -1) do
+      delete :destroy, id: @premonition
+    end
+
+    assert_redirected_to premonitions_path
+  end
+end

--- a/test/fixtures/premonitions.yml
+++ b/test/fixtures/premonitions.yml
@@ -1,0 +1,33 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  title: MyString
+  date: MyString
+  type: 
+  type_description: MyString
+  description: MyString
+  location_user: MyString
+  location_premonition: MyString
+  premonition_come_true: MyString
+  premonition_come_true_description: MyString
+  someone_else: MyString
+  own_conclusions: MyString
+  more_premonitions: MyString
+  tags: MyString
+  status: 1
+
+two:
+  title: MyString
+  date: MyString
+  type: 
+  type_description: MyString
+  description: MyString
+  location_user: MyString
+  location_premonition: MyString
+  premonition_come_true: MyString
+  premonition_come_true_description: MyString
+  someone_else: MyString
+  own_conclusions: MyString
+  more_premonitions: MyString
+  tags: MyString
+  status: 1

--- a/test/helpers/premonitions_helper_test.rb
+++ b/test/helpers/premonitions_helper_test.rb
@@ -1,0 +1,4 @@
+require 'test_helper'
+
+class PremonitionsHelperTest < ActionView::TestCase
+end

--- a/test/models/premonition_test.rb
+++ b/test/models/premonition_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class PremonitionTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Command scaffold premonition:

rails generate scaffold Premonition title:string date:string type:string type_description:string description:string location_user:string location_premonition:string premonition_come_true:string premonition_come_true_description:string someone_else:string own_conclusions:string more_premonitions:string tags:string status:integer

Create this fields:

create mode 100644 app/assets/javascripts/premonitions.js.coffee
 create mode 100644 app/assets/stylesheets/premonitions.css.scss
 create mode 100644 app/controllers/premonitions_controller.rb
 create mode 100644 app/helpers/premonitions_helper.rb
 create mode 100644 app/models/premonition.rb
 create mode 100644 app/views/premonitions/_form.html.erb
 create mode 100644 app/views/premonitions/edit.html.erb
 create mode 100644 app/views/premonitions/index.html.erb
 create mode 100644 app/views/premonitions/index.json.jbuilder
 create mode 100644 app/views/premonitions/new.html.erb
 create mode 100644 app/views/premonitions/show.html.erb
 create mode 100644 app/views/premonitions/show.json.jbuilder
 create mode 100644 test/controllers/premonitions_controller_test.rb
 create mode 100644 test/fixtures/premonitions.yml
 create mode 100644 test/helpers/premonitions_helper_test.rb
 create mode 100644 test/models/premonition_test.rb
